### PR TITLE
DB connection error when there is not db connection info on settings.php

### DIFF
--- a/terminatur.database.inc
+++ b/terminatur.database.inc
@@ -123,9 +123,7 @@ function _terminatur_data_get_db_creds($site, $destination, $db_user, $db_pass, 
       return _terminatur_data_get_db_creds($site, $destination, $db_user, $db_pass, $db_host, $db_port);
     }
   }
-  else {
-    return _terminatur_data_test_db_connection(_terminatur_data_parse_db_url($db_url, NULL));
-  }
+  return _terminatur_data_test_db_connection(_terminatur_data_parse_db_url($db_url, NULL));
 }
 
 /**


### PR DESCRIPTION
Sometimes code exist but there is no db connection string on settings.php, so we can't connect to database. We need to consider this case and return environment default connection info.
