### PR TITLE
when crushing a site, we should delete db, files, then code – in that order

### DIFF
--- a/terminatur.drush.inc
+++ b/terminatur.drush.inc
@@ -428,17 +428,16 @@ function drush_terminatur_crushsite($sitename = FALSE) {
 
   drush_log(dt("Removing site..."), 'warning');
 
-  // @todo: to be consistence maybe we want these to be abstracted out a bit?
+  // @todo: to be consistent maybe we want these to be abstracted out a bit?
+  if (!_terminatur_data_remove($site, $destination, $db_user, $db_pass, $db_host, $db_port)) {
+    return;
+  }
   if (!_terminatur_files_remove($site, $destination)) {
     return;
   }
   if (!_terminatur_code_remove($site, $destination)) {
     return;
   }
-  if (!_terminatur_data_remove($site, $destination, $db_user, $db_pass, $db_host, $db_port)) {
-    return;
-  }
-
 
   // Build vhost remove callback function
   $get_vhost_remove_func = '_terminatur_vhost_remove_' . TERMINATUR_ENV;


### PR DESCRIPTION
If we try to delete the files after, this happens:

```
Executing: rm -rf /var/www/mysite
Executing: rm -rf /home/vagrant/mysite/sites/default/files
```

and with this change:

```
Executing: rm -rf /var/www/mysite/sites/default/files
Executing: rm -rf /var/www/mysite
```
