### PR TITLE
Add site alias list to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ they're missing.
 
     # Authenticate with Pantheon and pull down your aliases
     drush ta
+    # List terminatur site aliases
+    drush sa | grep terminatur
     # Download a site with all its files
     drush pullsite mysite.dev # mysite.dev is from the alias @terminatur.mysite.dev
     # Remove this site


### PR DESCRIPTION
Added information to the quickstart guide to include listing the site aliases terminatur has acquired after running drush ta.  Long-term it may be better if drush ta output this information on completion.

Issue #29 
